### PR TITLE
clipboard copy resolve update utils.tsx

### DIFF
--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -1129,17 +1129,32 @@ export function identifierToHuman(identifier: string | number, caseType: 'senten
     )
 }
 
-export function parseGithubRepoURL(url: string): Record<string, string> {
-    const match = url.match(
-        /^https?:\/\/(?:www\.)?github\.com\/([A-Za-z0-9_.\-]+)\/([A-Za-z0-9_.\-]+)(\/(commit|tree|releases\/tag)\/([A-Za-z0-9_.\-\/]+))?/
-    )
+export async function copyToClipboard(value: string, description: string = 'text'): Promise<boolean> {
+  if (!navigator.clipboard) {
+    lemonToast.warning('Oops! Clipboard capabilities are only available over HTTPS or on localhost');
+    return false;
+  }
 
-    if (!match) {
-        throw new Error(`${url} is not a valid GitHub URL`)
+  try {
+    await navigator.clipboard.writeText(value);
+    lemonToast.info(`Copied ${description} to clipboard`);
+    return true;
+  } catch (e) {
+    // If the Clipboard API fails, fallback to textarea method
+    try {
+      const textArea = document.createElement('textarea');
+      textArea.value = value;
+      document.body.appendChild(textArea);
+      textArea.select();
+      document.execCommand('copy');
+      document.body.removeChild(textArea);
+      lemonToast.info(`Copied ${description} to clipboard`);
+      return true;
+    } catch (err) {
+      lemonToast.error(`Could not copy ${description} to clipboard: ${err}`);
+      return false;
     }
-
-    const [, user, repo, , type, path] = match
-    return { user, repo, type, path }
+  }
 }
 
 export function someParentMatchesSelector(element: HTMLElement, selector: string): boolean {

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -1129,6 +1129,18 @@ export function identifierToHuman(identifier: string | number, caseType: 'senten
     )
 }
 
+export function parseGithubRepoURL(url: string): Record<string, string> {
+    const match = url.match(
+        /^https?:\/\/(?:www\.)?github\.com\/([A-Za-z0-9_.\-]+)\/([A-Za-z0-9_.\-]+)(\/(commit|tree|releases\/tag)\/([A-Za-z0-9_.\-\/]+))?/
+    )
+
+    if (!match) {
+        throw new Error(`${url} is not a valid GitHub URL`)
+    }
+
+    const [, user, repo, , type, path] = match
+    return { user, repo, type, path }
+
 export async function copyToClipboard(value: string, description: string = 'text'): Promise<boolean> {
   if (!navigator.clipboard) {
     lemonToast.warning('Oops! Clipboard capabilities are only available over HTTPS or on localhost');

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -48,6 +48,7 @@ import { BehavioralFilterKey } from 'scenes/cohorts/CohortFilters/types'
 import { extractExpressionComment } from '~/queries/nodes/DataTable/utils'
 import { urls } from 'scenes/urls'
 import { isFunnelsFilter } from 'scenes/insights/sharedUtils'
+import { CUSTOM_OPTION_KEY } from './components/DateFilter/dateFilterLogic'
 
 export const ANTD_TOOLTIP_PLACEMENTS: Record<any, AlignType> = {
     // `@yiminghe/dom-align` objects
@@ -408,7 +409,7 @@ export function formatLabel(label: string, action: ActionFilter): string {
     return label.trim()
 }
 
-/** Check objects for deep equality, including "ordering" of properties */
+/** Compare objects deeply. */
 export function objectsEqual(obj1: any, obj2: any): boolean {
     return equal(obj1, obj2)
 }
@@ -801,7 +802,7 @@ export const formatDateRange = (dateFrom: dayjs.Dayjs, dateTo: dayjs.Dayjs, form
 }
 
 export const dateMapping: DateMappingOption[] = [
-    { key: 'Custom', values: [] },
+    { key: CUSTOM_OPTION_KEY, values: [] },
     {
         key: 'Today',
         values: ['dStart'],
@@ -933,7 +934,7 @@ export function dateFilterToText(
     }
 
     for (const { key, values, getFormattedDate } of dateOptions) {
-        if (values[0] === dateFrom && values[1] === dateTo && key !== 'Custom') {
+        if (values[0] === dateFrom && values[1] === dateTo && key !== CUSTOM_OPTION_KEY) {
             return isDateFormatted && getFormattedDate ? getFormattedDate(dayjs(), dateFormat) : key
         }
     }
@@ -1140,33 +1141,6 @@ export function parseGithubRepoURL(url: string): Record<string, string> {
 
     const [, user, repo, , type, path] = match
     return { user, repo, type, path }
-
-export async function copyToClipboard(value: string, description: string = 'text'): Promise<boolean> {
-  if (!navigator.clipboard) {
-    lemonToast.warning('Oops! Clipboard capabilities are only available over HTTPS or on localhost');
-    return false;
-  }
-
-  try {
-    await navigator.clipboard.writeText(value);
-    lemonToast.info(`Copied ${description} to clipboard`);
-    return true;
-  } catch (e) {
-    // If the Clipboard API fails, fallback to textarea method
-    try {
-      const textArea = document.createElement('textarea');
-      textArea.value = value;
-      document.body.appendChild(textArea);
-      textArea.select();
-      document.execCommand('copy');
-      document.body.removeChild(textArea);
-      lemonToast.info(`Copied ${description} to clipboard`);
-      return true;
-    } catch (err) {
-      lemonToast.error(`Could not copy ${description} to clipboard: ${err}`);
-      return false;
-    }
-  }
 }
 
 export function someParentMatchesSelector(element: HTMLElement, selector: string): boolean {

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -1011,23 +1011,32 @@ export function dateStringToDayJs(date: string | null): dayjs.Dayjs | null {
 }
 
 export async function copyToClipboard(value: string, description: string = 'text'): Promise<boolean> {
-    if (!navigator.clipboard) {
-        lemonToast.warning('Oops! Clipboard capabilities are only available over HTTPS or on localhost')
-        return false
-    }
+  if (!navigator.clipboard) {
+    lemonToast.warning('Oops! Clipboard capabilities are only available over HTTPS or on localhost');
+    return false;
+  }
 
+  try {
+    await navigator.clipboard.writeText(value);
+    lemonToast.info(`Copied ${description} to clipboard`);
+    return true;
+  } catch (e) {
+    // If the Clipboard API fails, fallback to textarea method
     try {
-        await navigator.clipboard.writeText(value)
-        lemonToast.info(`Copied ${description} to clipboard`, {
-            icon: <IconCopy />,
-        })
-        return true
-    } catch (e) {
-        lemonToast.error(`Could not copy ${description} to clipboard: ${e}`)
-        return false
+      const textArea = document.createElement('textarea');
+      textArea.value = value;
+      document.body.appendChild(textArea);
+      textArea.select();
+      document.execCommand('copy');
+      document.body.removeChild(textArea);
+      lemonToast.info(`Copied ${description} to clipboard`);
+      return true;
+    } catch (err) {
+      lemonToast.error(`Could not copy ${description} to clipboard: ${err}`);
+      return false;
     }
-}
-
+  }
+    
 export function clamp(value: number, min: number, max: number): number {
     return value > max ? max : value < min ? min : value
 }


### PR DESCRIPTION
## Problem
Not all browsers support navigator.clipboard.writeText  ticket #16059 

<!-- Who are we building for, what are their needs, why is this important? -->
This solution is for the browsers that did not support the clipboard copy API like duck duck go.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
We created a fallback using document.execCommand('copy')  if navigator.clipboard fails to copy the text.

![posthog2](https://github.com/codeday-labs/posthog/assets/115499083/4a7a6c57-74d4-447a-9adc-513b7a255b46)
![posthog1](https://github.com/codeday-labs/posthog/assets/115499083/1258e3a3-f9a8-4489-b26c-99040acffed8)


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->

We downloaded duckduck go browser on an android, ran the posthog on it and tried the copy to clipboard feature which worked but initially was not.

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
